### PR TITLE
feat: Graceful update

### DIFF
--- a/optimus_template.yaml
+++ b/optimus_template.yaml
@@ -39,7 +39,6 @@ marketplace:
   # Minimum price threshold for fetching orders from the marketplace.
   # Used to prevent regression poisoning.
   # Optional.
-  # Default value is 0.0001 USD/h, which is nearly about 1 USD per year.
   min_price: {{OPTIMUS_MIN_PRICE}} USD/h
 
 # Optimization engine settings.
@@ -156,7 +155,7 @@ workers:
     # Default value is 60s.
     epoch: 60s
     # How the bot should filter orders. Possible values are: "spot_only".
-    order_duration_threshold: 24h
+    order_duration_threshold: 72h
     # Orders that haven't been sold for this interval will be canceled.
     # Optional.
     # Default value is 5m.

--- a/optimus_template.yaml
+++ b/optimus_template.yaml
@@ -39,7 +39,7 @@ marketplace:
   # Minimum price threshold for fetching orders from the marketplace.
   # Used to prevent regression poisoning.
   # Optional.
-  min_price: {{OPTIMUS_MIN_PRICE}} USD/h
+  min_price: 0.01 USD/h
 
 # Optimization engine settings.
 optimization: &optimization

--- a/sonm-auto-deploy-supplier.sh
+++ b/sonm-auto-deploy-supplier.sh
@@ -76,6 +76,9 @@ install_sonm_packages() {
     apt-get update &> /dev/null
     echo "done."
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y sonm-cli sonm-node sonm-worker sonm-optimus
+    if ! [[ -z $(echo $SONM_VERSION) ]]; then
+        apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y sonm-mon
+    fi
     echo "Sonm packages installed"
 }
 

--- a/sonm-auto-deploy-supplier.sh
+++ b/sonm-auto-deploy-supplier.sh
@@ -240,7 +240,7 @@ fi
 
 if [ -f "/usr/bin/sonmworker" ]; then # Graceful update
     MASTER_ADDRESS=$(cat /etc/sonm/worker-default.yaml | grep master | grep 0x | awk '{print $2}')
-    echo "Looks like Sonm is already installed, checking deals.."
+    echo "Looks like Sonm is already installed (master address is $MASTER_ADDRESS), checking deals.."
     if ! [[ -z $(pgrep sonmworker) ]]; then
         if ! [[ $(su ${actual_user} -c "sonmcli worker status --json |jq '.uptime'") -eq 0 ]]; then
             for i in $(su ${actual_user} -c "sonmcli worker ask-plan list --json | jq '.askPlans[].duration.nanoseconds'"); do
@@ -263,7 +263,7 @@ if [ -f "/usr/bin/sonmworker" ]; then # Graceful update
     
     systemctl stop sonm-worker
     install_sonm
-    
+
 else # Install sonm for supplier
     install_dependencies
     install_docker

--- a/sonm-auto-deploy-supplier.sh
+++ b/sonm-auto-deploy-supplier.sh
@@ -238,9 +238,8 @@ fi
 
 if [ -f "/usr/bin/sonmworker" ]; then # Graceful update
     MASTER_ADDRESS=$(cat /etc/sonm/worker-default.yaml | grep master | grep 0x | awk '{print $2}')
-    CLI_CMD="sonmcli --config=$HOME/.sonm/cli.yaml"
     echo "Looks like Sonm is already installed, checking deals.."
-    for i in $($CLI_CMD worker ask-plan list | grep deal -A1 | grep duration | awk '{print $2}' | cut -d "h" -f 1); do 
+    for i in $(su ${actual_user} -c "sonmcli worker ask-plan list | grep deal -A1 | grep duration | awk '{print $2}' | cut -d "h" -f 1"); do 
         if [[ $i -gt 0 ]]; then 
             echo "Forward deal found, you cannot perform update at the moment" 
             exit 1
@@ -249,7 +248,7 @@ if [ -f "/usr/bin/sonmworker" ]; then # Graceful update
         fi
     done
     
-    while ! [[ $($CLI_CMD worker ask-plan purge) -eq 0 ]]; do
+    while ! [[ $(su ${actual_user} -c "sonmcli worker ask-plan purge)" -eq 0 ]]; do
         echo ".. waiting for deal finish .."
         sleep 1
     done

--- a/sonm-auto-deploy-supplier.sh
+++ b/sonm-auto-deploy-supplier.sh
@@ -238,7 +238,7 @@ fi
 
 if [ -f "/usr/bin/sonmworker" ]; then # Graceful update
     MASTER_ADDRESS=$(cat /etc/sonm/worker-default.yaml | grep master | grep 0x | awk '{print $2}')
-    echo "Looks like Sonm is already installed, checking deals.."
+    echo "Looks like Sonm is already installed (master address is $MASTER_ADDRESS), checking deals.."
     for i in $(su ${actual_user} -c "sonmcli worker ask-plan list | grep deal -A1 | grep duration | awk '{print $2}' | cut -d "h" -f 1"); do 
         if [[ $i -gt 0 ]]; then 
             echo "Forward deal found, you cannot perform update at the moment" 

--- a/sonm-auto-deploy-supplier.sh
+++ b/sonm-auto-deploy-supplier.sh
@@ -248,7 +248,7 @@ if [ -f "/usr/bin/sonmworker" ]; then # Graceful update
         fi
     done
     
-    while ! [[ $(su ${actual_user} -c "sonmcli worker ask-plan purge)" -eq 0 ]]; do
+    while ! [[ $(su ${actual_user} -c "sonmcli worker ask-plan purge") -eq 0 ]]; do
         echo ".. waiting for deal finish .."
         sleep 1
     done


### PR DESCRIPTION
If Sonm already installed, performs check for current deals. Interrupts update procedure if forward deal found. If there are no forward deals - closes spot  deals and installs updates.
Updates sonm-mon if Sonm OS detected.
Makes a copy of installation script named as /usr/bin/sonm-update. Further update of Sonm platform components will be easy as 'sudo sonm-update'.
Minor changes: Changed default price and max deal duration in Optimus config.